### PR TITLE
[feature/me-profile] mock 데이터를 이용한 프로필 사이드바 컴포넌트 구현

### DIFF
--- a/src/app/me/components/ProfileSidebar.tsx
+++ b/src/app/me/components/ProfileSidebar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+
+import SettingsIcon from "@/assets/icons/me-sns/me-register.svg";
+import ReceiptIcon from "@/assets/icons/me-sns/me-reservations.svg";
+import CalendarIcon from "@/assets/icons/me-sns/me-schedule.svg";
+import UserIcon from "@/assets/icons/me-sns/me.svg";
+import { ProfileImageUploader } from "@/components/ui/image-uploader";
+
+type ItemKey = "me" | "reservations" | "experiences" | "calendar";
+
+export default function ProfileSidebar({
+  initialProfileUrl,
+  selectedActivityId,
+}: {
+  initialProfileUrl?: string | null;
+  selectedActivityId: string;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // 현재 탭 계산
+  const active: ItemKey =
+    pathname.includes("/me/activities/") && pathname.endsWith("/schedule")
+      ? "calendar"
+      : pathname.startsWith("/me/reservations")
+        ? "reservations"
+        : pathname.startsWith("/me/activities")
+          ? "experiences"
+          : "me";
+
+  // 라우팅 경로
+  const toPath = (k: ItemKey) => {
+    switch (k) {
+      case "me":
+        return "/me";
+      case "reservations":
+        return "/me/reservations";
+      case "experiences":
+        return "/me/activities";
+      case "calendar":
+        return `/me/activities/${selectedActivityId}/schedule`;
+    }
+  };
+
+  const go = (k: ItemKey) => router.push(toPath(k));
+
+  const items: { k: ItemKey; label: string; icon: React.ReactNode }[] = [
+    { k: "me", label: "내 정보", icon: <UserIcon className="svg-fill h-6 w-6" /> },
+    { k: "reservations", label: "예약 내역", icon: <ReceiptIcon className="svg-fill h-6 w-6" /> },
+    {
+      k: "experiences",
+      label: "내 체험 관리",
+      icon: <SettingsIcon className="svg-fill h-6 w-6" />,
+    },
+    { k: "calendar", label: "예약 현황", icon: <CalendarIcon className="svg-fill h-6 w-6" /> },
+  ];
+
+  const Item = ({ k, label, icon }: { k: ItemKey; label: string; icon: React.ReactNode }) => {
+    const isActive = active === k;
+    return (
+      <button
+        type="button"
+        onClick={() => go(k)}
+        className={[
+          "rounded-12 flex w-full items-center gap-3.5 border-none px-4 py-[9px] text-left transition",
+          isActive ? "bg-brand-gray-300/50" : "hover:bg-brand-gray-200 bg-white",
+          isActive ? "text-brand-nomad-black" : "text-[#A4A1AA]",
+        ].join(" ")}
+      >
+        <span className="text-lg">{icon}</span>
+        <span className="text-lg font-bold">{label}</span>
+      </button>
+    );
+  };
+
+  return (
+    <aside className="rounded-12 border-brand-gray-300 h-fit w-96 border bg-white p-6">
+      <div className="flex w-full flex-col items-center gap-6">
+        <ProfileImageUploader initialUrl={initialProfileUrl} />
+      </div>
+
+      <nav className="mt-6 space-y-2">
+        {items.map((it) => (
+          <Item key={it.k} k={it.k} label={it.label} icon={it.icon} />
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 import Button from "@/components/ui/button/Button";
 import Field from "@/components/ui/input/Field";
 import Input from "@/components/ui/input/Input";
+
+import ProfileSidebar from "./components/ProfileSidebar";
 
 interface FormValues {
   nickname: string;
@@ -15,6 +18,13 @@ interface FormValues {
 }
 
 export default function Mypage() {
+  // mock데이터
+  const me = {
+    nickname: "노마드유저",
+    email: "user@example.com",
+    profileImageUrl: null as string | null,
+  };
+
   const {
     register,
     handleSubmit,
@@ -40,10 +50,19 @@ export default function Mypage() {
   const onSubmit = async () => {
     // 추후 api 연동
   };
+  const pathname = usePathname();
+  const selectedActivityId = pathname.match(/\/me\/activities\/([^/]+)/)?.[1] ?? "mock-activity-id"; // TODO: 실제 값으로 교체
 
   return (
-    <main className="mx-auto mt-20 mb-[88px] w-full max-w-[792px]">
-      <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-8">
+    <main className="mx-auto mt-20 mb-[88px] flex w-full max-w-[1200px]">
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-[24rem_1fr]">
+        <ProfileSidebar
+          initialProfileUrl={me.profileImageUrl}
+          selectedActivityId={selectedActivityId}
+        />
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="w-full max-w-[792px] space-y-8">
         <div className="flex justify-between">
           <h1 className="text-brand-black text-3xl font-bold">내정보</h1>
           <Button


### PR DESCRIPTION
## ✨ 변경 사항

- src/app/me/components/ProfileSidebar.tsx : 프로필 사이드바 컴포넌트 구현 (ui 및 프로필 이미지 업로드, 라우팅)

## ✅ 체크리스트

- [x] 피그마 시안에 따른 UI 구현
- [x] mock데이터에 따른 경로 이동

## 📷 스크린샷 (UI 변경 시)
<img width="1270" height="662" alt="스크린샷 2025-10-15 오후 4 28 14" src="https://github.com/user-attachments/assets/20c01834-02ee-499c-a2b2-9f6b31f118e3" />
