### PR TITLE
[feature/api-login,signup] 로그인 및 회원가입 api 연동

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { Suspense } from "react";
 import { useForm } from "react-hook-form";
 
@@ -8,6 +9,7 @@ import Logo from "@/components/ui/brand/Logo";
 import Button from "@/components/ui/button/Button";
 import Field from "@/components/ui/input/Field";
 import Input from "@/components/ui/input/Input";
+import { useLogin } from "@/lib/api/auth/hooks";
 
 import KakaoSigninHandler from "./KakaoSigninHandler";
 
@@ -17,14 +19,33 @@ interface FormValues {
 }
 
 export default function Login() {
+  const router = useRouter();
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors, isValid, isSubmitting },
   } = useForm<FormValues>({ mode: "onBlur", defaultValues: { email: "", password: "" } });
 
-  const onSubmit = async () => {
-    // 추후 api 연동
+  const loginMutation = useLogin(false, {
+    onSuccess: () => {
+      router.push("/");
+    },
+    onError: (e: unknown) => {
+      const msg = (e as { message?: string })?.message ?? "";
+      if (/비밀번호/i.test(msg) || /password/i.test(msg)) {
+        alert("비밀번호가 일치하지 않습니다.");
+        setError("password", { type: "server", message: "비밀번호가 일치하지 않습니다." });
+      } else if (/이메일/i.test(msg) || /email/i.test(msg)) {
+        setError("email", { type: "server", message: "이메일 형식으로 작성해 주세요." });
+      } else {
+        setError("email", { type: "server", message: msg || "로그인에 실패했습니다." });
+      }
+    },
+  });
+
+  const onSubmit = async (v: FormValues) => {
+    await loginMutation.mutateAsync({ email: v.email.trim(), password: v.password });
   };
 
   return (
@@ -65,7 +86,7 @@ export default function Login() {
         <Button
           type="submit"
           variant="b"
-          isDisabled={!isValid || isSubmitting}
+          isDisabled={!isValid || isSubmitting || loginMutation.isPending}
           className="h-12 w-full text-lg"
         >
           {isSubmitting ? "로그인 중..." : "로그인"}

--- a/src/components/ui/modal/DrawerHeader.tsx
+++ b/src/components/ui/modal/DrawerHeader.tsx
@@ -12,7 +12,7 @@ export default function DrawerHeader() {
   const { title, prevStep, onClose, isClose, isBack } = useDrawerContext();
 
   return (
-    <div className="flex items-center justify-between border-b pb-2">
+    <div className="flex items-center justify-between pb-2">
       <AnimatePresence mode="popLayout" initial={false}>
         {isBack && (
           <motion.div


### PR DESCRIPTION
## 📌 관련 이슈

- #

## ✨ 변경 사항

- src/app/login/page.tsx 
- src/app/signup/page.tsx 
-> useLogin, useSignUp 훅 연결 
-> useOAuthSignIn, useOAuthSignUp 훅 연결, 토큰 발급 시 / 이동, 실패 시 /login
- src/components/ui/modal/DrawerHeader.tsx : 헤더 밑 구분선 제거

## ✅ 체크리스트

- [ ] 이메일 로그인 성공
- [ ] 카카오 간편회원가입 성공
- [ ] 이메일 회원가입 성공
- [ ] 카카오 간편회원가입 성공

## 📑참고자료

## 📷 스크린샷 (UI 변경 시)
<img width="392" height="208" alt="스크린샷 2025-10-21 오후 12 44 10" src="https://github.com/user-attachments/assets/edc2f277-23f0-436d-9fa0-6adc8644e63d" />

