### PR TITLE
Fix: 이미지 삭제 버그 수정

### DIFF
--- a/src/app/me/activities/[id]/edit/page.tsx
+++ b/src/app/me/activities/[id]/edit/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
@@ -13,6 +14,7 @@ import type { UpdateActivityReq, UpdateActivityRes } from "@/lib/api/my-activiti
 export type UpdateActivityFormValues = UpdateActivityReq & {
   subImageIds?: number[];
   scheduleIds?: number[];
+  subImageUrls?: string[];
 };
 
 export default function EditPage() {
@@ -20,6 +22,7 @@ export default function EditPage() {
   const { id } = useParams<{ id: string }>();
   const activityId = Number(id);
   const { showToast } = useToast();
+  const queryClient = useQueryClient();
 
   const { mutateAsync: updateActivity } = useUpdateMyActivity(false);
   const [defaultValues, setDefaultValues] = useState<UpdateActivityFormValues | null>(null);
@@ -48,7 +51,8 @@ export default function EditPage() {
       address,
       category,
       bannerImageUrl,
-      subImageUrlsToAdd: subImage,
+      subImageUrlsToAdd: [],
+      subImageUrls: subImage ?? [],
       subImageIdsToRemove: [],
       subImageIds: subImageIds,
       schedulesToAdd: schedules ?? [],
@@ -67,6 +71,7 @@ export default function EditPage() {
       isEdit
       apiActivity={updateActivity}
       onAfterSubmit={() => {
+        queryClient.invalidateQueries({ queryKey: ["activityDetail", activityId] });
         showToast("update");
         router.push("/me/activities");
       }}

--- a/src/app/me/activities/register/components/ImageField.tsx
+++ b/src/app/me/activities/register/components/ImageField.tsx
@@ -3,7 +3,6 @@ import { Controller, FieldError, FieldValues, useFormContext } from "react-hook-
 import { subTitleClass } from "@/app/me/activities/register/components/MyActivityForm";
 import { ActivityImageUploader } from "@/components/ui/image-uploader";
 import Field from "@/components/ui/input/Field";
-import { cn } from "@/lib/cn";
 
 interface ImageFieldProps {
   onMainChange: (files: (File | string)[]) => void;
@@ -65,7 +64,7 @@ export default function ImageField({
       <div>
         <span className={subTitleClass}>소개 이미지</span>
         <Controller
-          name="subImageUrls"
+          name={SUB_IMAGE}
           render={({ field }) => (
             <Field id={SUB_IMAGE} error={onFieldError(SUB_IMAGE)}>
               <ActivityImageUploader

--- a/src/app/me/activities/register/components/MyActivityForm.tsx
+++ b/src/app/me/activities/register/components/MyActivityForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { MutateOptions, UseMutateFunction } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { DefaultValues, FieldValues, FormProvider, useForm } from "react-hook-form";
 
 import DateField from "@/app/me/activities/register/components/DateField";
@@ -38,7 +38,7 @@ export default function MyActivityForm<TReq extends FieldValues, TRes>({
 
   const initialActivityId = (defaultValues as UpdateActivityReq)?.activityId ?? 0;
   const initialMainUrls = defaultValues?.bannerImageUrl ?? "";
-  const initialSubUrls = defaultValues?.subImageUrlsToAdd ?? [];
+  const initialSubUrls = defaultValues?.subImageUrls ?? [];
   const initialSubIds = defaultValues?.subImageIds ?? [];
 
   const propsMainImages = isEdit ? [initialMainUrls] : [];
@@ -73,13 +73,12 @@ export default function MyActivityForm<TReq extends FieldValues, TRes>({
 
     if (isEdit) {
       const bannerImageUrl = await diffMainImages(initialMainUrls, bannerItems, uploadImage);
-      const { subImageUrlsToAdd } = await diffSubImages(
+      const { subImageUrlsToAdd, subImageIdsToRemove } = await diffSubImages(
         initialSubUrls,
         initialSubIds,
         subItems,
         uploadImage,
       );
-      const subImageIdsToRemove = initialSubIds;
 
       const payload: UpdateActivityReq = {
         ...(data as unknown as UpdateActivityReq),

--- a/src/components/ui/image-uploader/hooks/useImageUploader.ts
+++ b/src/components/ui/image-uploader/hooks/useImageUploader.ts
@@ -47,7 +47,11 @@ export function useImageUploader({
   });
 
   useEffect(() => {
-    if (initialImages.length && JSON.stringify(initialImages) !== JSON.stringify(images)) {
+    if (
+      initialImages.length > 0 &&
+      images.length > 0 &&
+      JSON.stringify(initialImages) !== JSON.stringify(images)
+    ) {
       setImages(initialImages);
     }
   }, [JSON.stringify(initialImages)]);


### PR DESCRIPTION
## 📌 관련 이슈

- #60 

## ✨ 변경 사항

<!-- 어떤 점이 변경되었는지 설명해주세요 -->

- 삭제만 진행했을 때 subImageUrlsToAdd에 기존 배열이 다시 들어오고 있었다.
- `DiffImage.ts` 에서 수정하거나 추가되는 파일이 없을 때 빈 배열로 return하고
- 수정페이지에서 init을 subImageUrlsToAdd로 보내고 있었는데 초기값을 그대로 가지고 있어서 초기값을 따로 보내주고,
- `MyActivityForm.tsx` 에서 추가되는 이미지가 있을 때 배열로 들어갈 수 있게 수정했습니다

## ✅ 체크리스트

- [x] 빌드 및 테스트가 통과됨
- [ ] 코드 리뷰 반영 완료

## 📑참고자료

## 📷 스크린샷 (UI 변경 시)
